### PR TITLE
handle PullRequestID passed as an empty variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -149,7 +149,7 @@ func (build build) buildType() string {
 	switch {
 	case build.Tag != "":
 		return buildTypeTag
-	case *build.PullRequestID > 0 || (build.PullRequestTargetBranch != ""):
+		case (build.PullRequestID != nil && *build.PullRequestID > 0) || (build.PullRequestTargetBranch != ""):
 		return buildTypePullRequest
 	case build.CommitHash == "":
 		return buildTypeManual

--- a/main.go
+++ b/main.go
@@ -93,6 +93,8 @@ func (cfg config) getBuilds(f filter) (builds, error) {
 	if resp.StatusCode != 200 {
 		return builds{}, fmt.Errorf("invalid response status code: %d\nbody: %s", resp.StatusCode, string(body))
 	}
+	
+	log.Printf("%s", body)
 
 	var builds struct {
 		Data []build `json:"data"`

--- a/main.go
+++ b/main.go
@@ -79,6 +79,9 @@ func (cfg config) getBuilds(f filter) (builds, error) {
 	req.Header.Add("accept", "application/json")
 	req.Header.Add("Authorization", string(cfg.AccessToken))
 
+	log.Printf("%s", req)
+	log.Printf("%s", req.URL.RawQuery)
+	
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -225,6 +228,8 @@ func main() {
 		failf("- Failed to get similar builds, error: %s", err)
 	}
 	log.Printf("%d builds found", len(similarBuilds))
+	log.Printf("similarBuilds %s", similarBuilds)
+	log.Printf("currentBuild %s", currentBuild)
 	log.Donef("- Done")
 	fmt.Println()
 

--- a/main.go
+++ b/main.go
@@ -79,6 +79,8 @@ func (cfg config) getBuilds(f filter) (builds, error) {
 	req.Header.Add("accept", "application/json")
 	req.Header.Add("Authorization", string(cfg.AccessToken))
 
+	log.Printf("%s", req)
+	log.Printf("%s", req.URL.RawQuery)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -222,6 +222,8 @@ func main() {
 		failf("- Failed to get similar builds, error: %s", err)
 	}
 	log.Printf("%d builds found", len(similarBuilds))
+	log.Printf("similarBuilds %s", similarBuilds)
+	log.Printf("currentBuild %s", currentBuild)
 	log.Donef("- Done")
 	fmt.Println()
 

--- a/main.go
+++ b/main.go
@@ -79,8 +79,6 @@ func (cfg config) getBuilds(f filter) (builds, error) {
 	req.Header.Add("accept", "application/json")
 	req.Header.Add("Authorization", string(cfg.AccessToken))
 
-	log.Printf("%s", req)
-	log.Printf("%s", req.URL.RawQuery)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -104,6 +102,8 @@ func (cfg config) getBuilds(f filter) (builds, error) {
 
 type filter struct {
 	Before           int    `url:"before,omitempty"`
+	After            int    `url:"after,omitempty"`
+	Limit            int    `url:"limit,omitempty"`
 	Branch           string `url:"branch,omitempty"`
 	SortBy           string `url:"sort_by,omitempty"`
 	Workflow         string `url:"workflow,omitempty"`
@@ -134,6 +134,7 @@ func (build build) generateFilter() filter {
 		Workflow: build.TriggeredWorkflow,
 		Branch:   build.Branch,
 		Before:   int(build.TriggeredAt.Unix()),
+		After:    int(build.TriggeredAt.Unix()) - 24*60*60
 	}
 	switch build.buildType() {
 	case buildTypeTag:
@@ -224,8 +225,6 @@ func main() {
 		failf("- Failed to get similar builds, error: %s", err)
 	}
 	log.Printf("%d builds found", len(similarBuilds))
-	log.Printf("similarBuilds %s", similarBuilds)
-	log.Printf("currentBuild %s", currentBuild)
 	log.Donef("- Done")
 	fmt.Println()
 

--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func (build build) generateFilter() filter {
 		Workflow: build.TriggeredWorkflow,
 		Branch:   build.Branch,
 		Before:   int(build.TriggeredAt.Unix()),
-		After:    int(build.TriggeredAt.Unix()) - 24*60*60
+		After:    int(build.TriggeredAt.Unix()) - 24*60*60,
 	}
 	switch build.buildType() {
 	case buildTypeTag:


### PR DESCRIPTION
Hello, I ran into an issue running the step in a build triggered from the trigger-bitrise-workflow step. trigger-bitrise-workflow will, by default, insert pull_request_id in the build parameters as an empty string. This will cause build-status-change to dereference garbage, leading to:

Getting current build
Build info:
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1282296]

This change avoids the issue. (Manually removing pull_request_id from the trigger-bitrise-workflow step also works, but this change allows the two steps to work together by default.)