### PR TITLE
Tool 978 nil deref

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -19,6 +19,7 @@ workflows:
     - path::./:
         inputs:
         - access_token: $BITRISE_ACCESS_TOKEN
+        - verbose: "yes"
 
   audit-this-step:
     steps:

--- a/main.go
+++ b/main.go
@@ -149,7 +149,7 @@ func (build build) buildType() string {
 	switch {
 	case build.Tag != "":
 		return buildTypeTag
-	case *build.PullRequestID > 0 || (build.PullRequestTargetBranch != ""):
+		case (build.PullRequestID != nil && *build.PullRequestID > 0) || (build.PullRequestTargetBranch != ""):
 		return buildTypePullRequest
 	case build.CommitHash == "":
 		return buildTypeManual

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httputil"
 	"os"
 	"time"
 
@@ -91,8 +92,11 @@ func (cfg config) getBuilds(f filter) (builds, error) {
 	req.Header.Add("accept", "application/json")
 	req.Header.Add("Authorization", string(cfg.AccessToken))
 
-	log.Debugf("getBuilds http request: %s", req)
-	log.Debugf("getBuilds http query: %s", req.URL.RawQuery)
+	requestBytes, err := httputil.DumpRequest(req, true)
+	if err != nil {
+		log.Warnf("failed to dump request: %s", err)
+	}
+	log.Debugf("Get builds raw request: %s", requestBytes)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -112,7 +116,11 @@ func (cfg config) getBuilds(f filter) (builds, error) {
 		return builds{}, fmt.Errorf("invalid response status code: %d\nbody: %s", resp.StatusCode, string(body))
 	}
 
-	log.Printf("%s", body)
+	responseBytes, err := httputil.DumpResponse(resp, true)
+	if err != nil {
+		log.Warnf("failed to dump response, error: %s", err)
+	}
+	log.Debugf("Get builds raw response: %s", responseBytes)
 
 	var builds struct {
 		Data []build `json:"data"`

--- a/main.go
+++ b/main.go
@@ -93,6 +93,8 @@ func (cfg config) getBuilds(f filter) (builds, error) {
 	if resp.StatusCode != 200 {
 		return builds{}, fmt.Errorf("invalid response status code: %d\nbody: %s", resp.StatusCode, string(body))
 	}
+	
+	log.Printf("%s", body)
 
 	var builds struct {
 		Data []build `json:"data"`

--- a/main.go
+++ b/main.go
@@ -79,6 +79,9 @@ func (cfg config) getBuilds(f filter) (builds, error) {
 	req.Header.Add("accept", "application/json")
 	req.Header.Add("Authorization", string(cfg.AccessToken))
 
+	log.Printf("%s", req)
+	log.Printf("%s", req.URL.RawQuery)
+	
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -225,6 +228,8 @@ func main() {
 		failf("- Failed to get similar builds, error: %s", err)
 	}
 	log.Printf("%d builds found", len(similarBuilds))
+	log.Printf("similarBuilds %s", similarBuilds)
+	log.Printf("currentBuild %s", currentBuild)
 	log.Donef("- Done")
 	fmt.Println()
 

--- a/main.go
+++ b/main.go
@@ -54,6 +54,12 @@ func (cfg config) getBuild() (build, error) {
 	if err != nil {
 		return build{}, err
 	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Warnf("failed to close response (%s) body, error: %s", resp, err)
+		}
+	}()
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return build{}, err
@@ -92,6 +98,12 @@ func (cfg config) getBuilds(f filter) (builds, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Warnf("failed to close response (%s) body, error: %s", resp, err)
+		}
+	}()
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -92,11 +92,13 @@ func (cfg config) getBuilds(f filter) (builds, error) {
 	req.Header.Add("accept", "application/json")
 	req.Header.Add("Authorization", string(cfg.AccessToken))
 
-	requestBytes, err := httputil.DumpRequest(req, true)
-	if err != nil {
-		log.Warnf("failed to dump request: %s", err)
+	if cfg.VerboseLog {
+		requestBytes, err := httputil.DumpRequest(req, true)
+		if err != nil {
+			log.Warnf("failed to dump request: %s", err)
+		}
+		log.Debugf("Get builds raw request: %s", requestBytes)
 	}
-	log.Debugf("Get builds raw request: %s", requestBytes)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -116,11 +118,13 @@ func (cfg config) getBuilds(f filter) (builds, error) {
 		return builds{}, fmt.Errorf("invalid response status code: %d\nbody: %s", resp.StatusCode, string(body))
 	}
 
-	responseBytes, err := httputil.DumpResponse(resp, true)
-	if err != nil {
-		log.Warnf("failed to dump response, error: %s", err)
+	if cfg.VerboseLog {
+		responseBytes, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			log.Warnf("failed to dump response, error: %s", err)
+		}
+		log.Debugf("Get builds raw response: %s", responseBytes)
 	}
-	log.Debugf("Get builds raw response: %s", responseBytes)
 
 	var builds struct {
 		Data []build `json:"data"`

--- a/main.go
+++ b/main.go
@@ -79,6 +79,8 @@ func (cfg config) getBuilds(f filter) (builds, error) {
 	req.Header.Add("accept", "application/json")
 	req.Header.Add("Authorization", string(cfg.AccessToken))
 
+	log.Printf("%s", req)
+	log.Printf("%s", req.URL.RawQuery)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ type config struct {
 	BuildStatus         string          `env:"BITRISE_BUILD_STATUS,required"`
 	PreviousBuildStatus string          `env:"PREVIOUS_BUILD_STATUS"`
 	AccessToken         stepconf.Secret `env:"access_token,required"`
+	VerboseLog          bool            `env:"verbose_log,opt[yes,no]"`
 }
 
 func (cfg config) getBuild() (build, error) {
@@ -84,8 +85,8 @@ func (cfg config) getBuilds(f filter) (builds, error) {
 	req.Header.Add("accept", "application/json")
 	req.Header.Add("Authorization", string(cfg.AccessToken))
 
-	log.Printf("%s", req)
-	log.Printf("%s", req.URL.RawQuery)
+	log.Debugf("getBuilds http request: %s", req)
+	log.Debugf("getBuilds http query: %s", req.URL.RawQuery)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -206,6 +207,7 @@ func main() {
 	}
 	stepconf.Print(cfg)
 	fmt.Println()
+	log.SetEnableDebugLog(cfg.VerboseLog)
 
 	if cfg.PreviousBuildStatus != "" {
 		log.Infof("Exporting environment variables:")
@@ -236,8 +238,8 @@ func main() {
 		failf("- Failed to get similar builds, error: %s", err)
 	}
 	log.Printf("%d builds found", len(similarBuilds))
-	log.Printf("similarBuilds %s", similarBuilds)
-	log.Printf("currentBuild %s", currentBuild)
+	log.Debugf("similarBuilds %s", similarBuilds)
+	log.Debugf("currentBuild %s", currentBuild)
 	log.Donef("- Done")
 	fmt.Println()
 

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ type config struct {
 	BuildStatus         string          `env:"BITRISE_BUILD_STATUS,required"`
 	PreviousBuildStatus string          `env:"PREVIOUS_BUILD_STATUS"`
 	AccessToken         stepconf.Secret `env:"access_token,required"`
-	VerboseLog          bool            `env:"verbose_log,opt[yes,no]"`
+	VerboseLog          bool            `env:"verbose,opt[yes,no]"`
 }
 
 func (cfg config) getBuild() (build, error) {

--- a/main.go
+++ b/main.go
@@ -222,6 +222,8 @@ func main() {
 		failf("- Failed to get similar builds, error: %s", err)
 	}
 	log.Printf("%d builds found", len(similarBuilds))
+	log.Printf("similarBuilds %s", similarBuilds)
+	log.Printf("currentBuild %s", currentBuild)
 	log.Donef("- Done")
 	fmt.Println()
 

--- a/main.go
+++ b/main.go
@@ -79,8 +79,6 @@ func (cfg config) getBuilds(f filter) (builds, error) {
 	req.Header.Add("accept", "application/json")
 	req.Header.Add("Authorization", string(cfg.AccessToken))
 
-	log.Printf("%s", req)
-	log.Printf("%s", req.URL.RawQuery)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -104,6 +102,8 @@ func (cfg config) getBuilds(f filter) (builds, error) {
 
 type filter struct {
 	Before           int    `url:"before,omitempty"`
+	After            int    `url:"after,omitempty"`
+	Limit            int    `url:"limit,omitempty"`
 	Branch           string `url:"branch,omitempty"`
 	SortBy           string `url:"sort_by,omitempty"`
 	Workflow         string `url:"workflow,omitempty"`
@@ -134,6 +134,7 @@ func (build build) generateFilter() filter {
 		Workflow: build.TriggeredWorkflow,
 		Branch:   build.Branch,
 		Before:   int(build.TriggeredAt.Unix()),
+		After:    int(build.TriggeredAt.Unix()) - 24*60*60
 	}
 	switch build.buildType() {
 	case buildTypeTag:
@@ -224,8 +225,6 @@ func main() {
 		failf("- Failed to get similar builds, error: %s", err)
 	}
 	log.Printf("%d builds found", len(similarBuilds))
-	log.Printf("similarBuilds %s", similarBuilds)
-	log.Printf("currentBuild %s", currentBuild)
 	log.Donef("- Done")
 	fmt.Println()
 

--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func (build build) generateFilter() filter {
 		Workflow: build.TriggeredWorkflow,
 		Branch:   build.Branch,
 		Before:   int(build.TriggeredAt.Unix()),
-		After:    int(build.TriggeredAt.Unix()) - 24*60*60
+		After:    int(build.TriggeredAt.Unix()) - 24*60*60,
 	}
 	switch build.buildType() {
 	case buildTypeTag:

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_build_buildType(t *testing.T) {
+	dereferenceInt := func(i int64) *int64 {
+		return &i
+	}
+
+	type fields struct {
+		Tag                     string
+		Slug                    string
+		Branch                  string
+		Status                  int
+		CommitHash              string
+		StatusText              string
+		TriggeredAt             time.Time
+		BuildNumber             int64
+		PullRequestID           *int64
+		TriggeredWorkflow       string
+		PullRequestTargetBranch string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   buildType
+	}{
+		{
+			name: "pull request ID nil, target branch exists",
+			fields: fields{
+				Tag:                     "",
+				PullRequestID:           nil,
+				PullRequestTargetBranch: "master",
+				CommitHash:              "",
+			},
+			want: buildTypePullRequest,
+		},
+		{
+			name: "pull request ID not nil, target branch exists",
+			fields: fields{
+				Tag:                     "",
+				PullRequestID:           dereferenceInt(1),
+				PullRequestTargetBranch: "master",
+				CommitHash:              "",
+			},
+			want: buildTypePullRequest,
+		},
+		{
+			name: "tag specified",
+			fields: fields{
+				Tag:                     "tag1",
+				PullRequestID:           nil,
+				PullRequestTargetBranch: "master",
+				CommitHash:              "234abc",
+			},
+			want: buildTypeTag,
+		},
+		{
+			name: "commit hash specified only",
+			fields: fields{
+				Tag:                     "",
+				PullRequestID:           nil,
+				PullRequestTargetBranch: "",
+				CommitHash:              "234abc",
+			},
+			want: buildTypePush,
+		},
+		{
+			name: "commit hash specified only",
+			fields: fields{
+				PullRequestID:           nil,
+				PullRequestTargetBranch: "",
+				Tag:                     "",
+				CommitHash:              "",
+			},
+			want: buildTypeManual,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			build := build{
+				Tag:                     tt.fields.Tag,
+				Slug:                    tt.fields.Slug,
+				Branch:                  tt.fields.Branch,
+				Status:                  tt.fields.Status,
+				CommitHash:              tt.fields.CommitHash,
+				StatusText:              tt.fields.StatusText,
+				TriggeredAt:             tt.fields.TriggeredAt,
+				BuildNumber:             tt.fields.BuildNumber,
+				PullRequestID:           tt.fields.PullRequestID,
+				TriggeredWorkflow:       tt.fields.TriggeredWorkflow,
+				PullRequestTargetBranch: tt.fields.PullRequestTargetBranch,
+			}
+			if got := build.buildType(); got != tt.want {
+				t.Errorf("build.buildType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/step.yml
+++ b/step.yml
@@ -28,7 +28,9 @@ inputs:
       title: Enable verbose logging?
       summary: Enable debug level logging, if set to "yes".
       description: Enable debug logging, if set to "yes".
-      value_options: ["no", "yes"]
+      value_options:
+        - "no"
+        - "yes"
       is_required: true
 
 outputs:

--- a/step.yml
+++ b/step.yml
@@ -23,7 +23,7 @@ inputs:
       description: Your access token for the account that has access to the Bitrise app.
       is_required: true
       is_sensitive: true
-  - verbose_log: "no"
+  - verbose: "no"
     opts:
       title: Enable verbose logging?
       summary: Enable debug level logging, if set to "yes".

--- a/step.yml
+++ b/step.yml
@@ -23,6 +23,13 @@ inputs:
       description: Your access token for the account that has access to the Bitrise app.
       is_required: true
       is_sensitive: true
+  - verbose_log: "no"
+    opts:
+      title: Enable verbose logging?
+      summary: Enable debug level logging, if set to "yes".
+      description: Enable debug logging, if set to "yes".
+      value_options: ["no", "yes"]
+      is_required: true
 
 outputs:
   - BUILD_STATUS_CHANGED:


### PR DESCRIPTION
Hello, I ran into an issue running the step in a build triggered from the trigger-bitrise-workflow step. trigger-bitrise-workflow will, by default, insert pull_request_id in the build parameters as an empty string. This will cause build-status-change to dereference garbage, leading to:

Getting current build
Build info:
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1282296]

This change avoids the issue. (Manually removing pull_request_id from the trigger-bitrise-workflow step also works, but this change allows the two steps to work together by default.)