### PR TITLE
Added PREVIOUS_BUILD_SLUG to output variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
     > True if the actual build status is different from the previous one.
 - PREVIOUS_BUILD_STATUS: Previous Build Status
     > Status text of the previous build.
+- PREVIOUS_BUILD_SLUG: Previous Build Slug
+    > The BITRISE_BUILD_SLUG of the previous build.
 
 ## Contribute
 

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ const (
 	baseURL                   = "https://api.bitrise.io/v0.1"
 	envKeyPreviousBuildStatus = "PREVIOUS_BUILD_STATUS"
 	envKeyBuildStatusChanged  = "BUILD_STATUS_CHANGED"
+	envKeyPreviousBuildSlug   = "PREVIOUS_BUILD_SLUG"
 	statusTextSuccessfulBuild = "success"
 )
 
@@ -282,6 +283,11 @@ func main() {
 		failf("failed to export env: %s, error: %s", envKeyPreviousBuildStatus, err)
 	}
 	log.Printf("- %s=%s", envKeyPreviousBuildStatus, matchingPreviousBuild.StatusText)
+
+	if err := tools.ExportEnvironmentWithEnvman(envKeyPreviousBuildSlug, matchingPreviousBuild.Slug); err != nil {
+		failf("failed to export env: %s, error: %s", envKeyPreviousBuildSlug, err)
+	}
+	log.Printf("- %s=%s", envKeyPreviousBuildSlug, matchingPreviousBuild.Slug)
 
 	currentBuildFailed := cfg.BuildStatus != "0"
 	changed := fmt.Sprintf("%t", currentBuildFailed != previousBuildFailed)

--- a/step.yml
+++ b/step.yml
@@ -44,3 +44,8 @@ outputs:
       title: "Previous Build Status"
       summary: Status text of the previous build.
       description: Status text of the previous build.
+  - PREVIOUS_BUILD_SLUG:
+    opts:
+      title: "Previous Build Slug"
+      summary: The BITRISE_BUILD_SLUG of the previous build.
+      description: The BITRISE_BUILD_SLUG of the previous build.


### PR DESCRIPTION

### Checklist
- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [X] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a  MINOR

### Context
This PR adds a new environment variable output called `PREVIOUS_BUILD_SLUG` following similar conventions to the existing `PREVIOUS_BUILD_STATUS`. This variable is useful when using this step for performing other checks if needed inside your calling workflows. 

For example, I want to use this step in combination with `PREVIOUS_BUILD_SLUG` to not only detect the change in the build, but also come with a list of files changed. In order to do that, what I do in my workflow is to get the build details via API, and then extract the commit hash or start date of the job. Then, I can just do some git diff to read the changes. This type of diffing can be very useful in nightly builds too, or reporting in slack or similar.


### Changes
- Added new output variable in step.yml and readme file
- Added a constant with the variable name and exported the value in the main.go

### Decisions

I decided to output the `PREVIOUS_BUILD_SLUG` and not other info like the commit hash, since manual builds could pontentially have no hash. Adding the slug allows the developer to just retrieve all relevant info and use whatever they want as part of their workflow.
